### PR TITLE
Feature: Output dir with SRT export

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@
 
 [TimeStampAudio](https://timestampaudio.com) generates timing data from any audio and corresponding text file combination, in the over [1,100 languages](https://dl.fbaipublicfiles.com/mms/misc/language_coverage_mms.html) supported by [Meta's MMS ASR model](https://ai.meta.com/blog/multilingual-model-speech-recognition/), outputting the results in JSON.
 
-
 ## Requirements:
 
 We have successfully run this tool on both MacOS and Linux laptops with only CPUs by simply running the command below.
 
-However, the MMS model works most efficiently with a CUDA enabled GPU. 
+However, the MMS model works most efficiently with a CUDA enabled GPU.
 
 While an Mac M1 Pro could timestamp a 10 minute audio file in about 2.5 minutes, that same file could be timestamped in _just a few seconds_ when processed with a GPU.
-
 
 ## Installation:
 
@@ -24,9 +22,9 @@ Installation is fairly straight-forward. Simply:
 ```sh
 pip install -r requirement
 ```
+
 3. Install `ffmpeg` and `sox` using your preferred method, e.g. `brew install ffmpeg sox`.
 4. You're ready to go!
-
 
 ## Usage:
 
@@ -34,9 +32,7 @@ To start timestamping, the first step is to organize your files.
 
 The script will process an entire directory, expecting to find pairs of files with matching names, in `.mp3` and `.txt` format. So `GEN.1.mp3` and `GEN.1.txt`
 
-
 When run on a directory, every pair of files with matching names will be processed.
-
 
 ```
 $ tree .
@@ -53,16 +49,14 @@ $ tree .
 └── GEN.5.txt
 ```
 
-
 \
 You can run the CLI tool with the following arguments:
 
 ```sh
-python main.py -i <input_folder> -o <output_file>.json [-s <separator>] [-l <language>]
+python main.py -i <input_folder> -o <output_folder>
 ```
 
-The script will output a single JSON file with an object for each audio-text file-pair.
-
+The script will output a JSON and a SRT file in the output directory for each audio-text file-pair.
 
 ### Arguments
 
@@ -70,9 +64,10 @@ The script will output a single JSON file with an object for each audio-text fil
 - `-o, --output` (required): The path to a JSON file to write the timestamps to.
 - `-s, --separator` (optional): The location to timestamp within a text file. Options are `lineBreak`, `leftBracket` ([), or `downArrow` (⬇️). Default is `lineBreak`.
 - `-l, --language` (optional): The language of the text and audio files. If not provided, the app will automatically detect the language using MMS's lid API.
+- `-m, --max-silence-padding-ms` (optional): The maximum amount of silence padding (in ms) to offset the start and end timestamps of each text span. Default is -1 (equally distribute silence). 0 will remove all silence. 500 (for example) will add up to 500ms of silence to the start and end of each text span.
 
 ## Example
 
 ```sh
-python main.py -i ./data -o timestamps.json -s lineBreak -l en
+python main.py -i ./input-dir -o ./output-dir -s lineBreak -l eng -m 0
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The script will output a JSON and a SRT file in the output directory for each au
 ### Arguments
 
 - `-i, --input` (required): The path to a folder containing audio and text files.
-- `-o, --output` (required): The path to a JSON file to write the timestamps to.
+- `-o, --output` (required): The path to a folder to write JSON and SRT files to.
 - `-s, --separator` (optional): The location to timestamp within a text file. Options are `lineBreak`, `leftBracket` ([), or `downArrow` (⬇️). Default is `lineBreak`.
 - `-l, --language` (optional): The language of the text and audio files. If not provided, the app will automatically detect the language using MMS's lid API.
 - `-m, --max-silence-padding-ms` (optional): The maximum amount of silence padding (in ms) to offset the start and end timestamps of each text span. Default is -1 (equally distribute silence). 0 will remove all silence. 500 (for example) will add up to 500ms of silence to the start and end of each text span.

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ parser.add_argument(
 parser.add_argument(
     "-o",
     "--output",
-    help="The path to an output directory to write JSON and SRT files to.",
+    help="The path to a folder to write JSON and SRT files to.",
     required=True,
 )
 parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -26,15 +26,33 @@ parser.add_argument(
 parser.add_argument(
     "-s",
     "--separator",
-    help="The location to timestamp within a text file. Options are `lineBreak`, `leftBracket` ([), or `downArrow` (⬇️).",
+    help=(
+        "The location to timestamp within a text file. Options are `lineBreak`, "
+        "`leftBracket` ([), or `downArrow` (⬇️)."
+    ),
     default="lineBreak",
 )
 parser.add_argument(
     "-l",
     "--language",
-    help="The language of the text and audio files. If one isn't provided, the app will automatically detect the language using MMS's lid api.",
+    help=(
+        "The language of the text and audio files. If one isn't provided, the app "
+        "will automatically detect the language using MMS's lid api."
+    ),
     default=None,
     type=str,
+)
+parser.add_argument(
+    "-m",
+    "--max-silence-padding-ms",
+    help=(
+        "The maximum amount of silence padding (in ms) to offset the start and end "
+        "timestamps of each text span. Default is -1 (equally distribute silence). "
+        "0 will remove all silence. 500 (for example) will add up to 500ms of "
+        "silence to the start and end of each text span."
+    ),
+    default=-1,
+    type=int,
 )
 
 
@@ -44,6 +62,7 @@ def main():
     output = args.output
     separator = args.separator
     language = args.language
+    max_silence_padding_ms = args.max_silence_padding_ms
 
     if language is not None:
         # Check if language is valid.
@@ -79,7 +98,7 @@ def main():
         if match[0] is None or match[1] is None:
             continue
     timestamps = align_matches(
-        folder, language, separator, matched_files, model, dictionary
+        folder, language, separator, matched_files, model, dictionary, max_silence_padding_ms
     )
     json.dump(timestamps, open(output, "w"))
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import time
 
 from halo import Halo
 
@@ -97,10 +98,15 @@ def main():
     for match in matched_files:
         if match[0] is None or match[1] is None:
             continue
+    
+    start_time = time.time()
     timestamps = align_matches(
         folder, language, separator, matched_files, model, dictionary, max_silence_padding_ms
     )
     json.dump(timestamps, open(output, "w"))
+    end_time = time.time()
+    
+    spinner.succeed(f"Done in {(end_time - start_time) * 1000:.2f} ms.")
 
 
 main()

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ def main():
     json.dump(timestamps, open(output, "w"))
     end_time = time.time()
     
-    spinner.succeed(f"Done in {(end_time - start_time) * 1000:.2f} ms.")
+    spinner.succeed(f"Done in {(end_time - start_time):.2f} seconds.")
 
 
 main()

--- a/mms/align_utils.py
+++ b/mms/align_utils.py
@@ -123,32 +123,6 @@ def time_to_frame(time: float):
     return int(time * frames_per_sec)
 
 
-def trim_silence_edges(span: List[Segment], silence_threshold: int):
-    """
-    Trim silence segments from the start and end of a span if they are longer than the specified threshold.
-    
-    Args:
-        span: List of Segments to trim
-        silence_threshold: Duration threshold (in frames) above which blank segments will be trimmed
-        
-    Returns:
-        List[Segment]: Trimmed span
-    """
-    # Return early if span is empty
-    if not span:
-        return span
-        
-    # Trim from start
-    while span and span[0].label == "<blank>" and span[0].length > silence_threshold:
-        span = span[1:]
-        
-    # Trim from end
-    while span and span[-1].label == "<blank>" and span[-1].length > silence_threshold:
-        span = span[:-1]
-        
-    return span
-
-
 def get_spans(tokens: List[str], segments: List[Segment], max_silence_padding_frames: int = -1):
     """
     Given a list of tokens (text strings), get the spans that correspond to the tokens.

--- a/utils.py
+++ b/utils.py
@@ -63,7 +63,7 @@ def align_matches(
     dictionary: Any,
 ):
     """
-    Align audio and text files and write output to Firestore.
+    Align audio and text files and return a list of FileTimestamps.
     """
     spinner = Halo("Aligning...").start()
 

--- a/utils.py
+++ b/utils.py
@@ -61,6 +61,7 @@ def align_matches(
     matches: list[Match],
     model: Any,
     dictionary: Any,
+    max_silence_padding_ms: int,
 ):
     """
     Align audio and text files and return a list of FileTimestamps.
@@ -221,9 +222,12 @@ def align_matches(
                 dictionary,
             )
 
-            max_silence_padding_ms = 500
-            max_silence_padding_frames = round(max_silence_padding_ms / stride)
-            spinner.info(f"max_silence_padding_frames: {max_silence_padding_frames}")
+            if max_silence_padding_ms >= 0:
+                max_silence_padding_frames = round(max_silence_padding_ms / stride)
+                spinner.info(f"Max Silence Padding: {max_silence_padding_ms}ms -> {max_silence_padding_frames} frames")
+            else:
+                max_silence_padding_frames = -1
+            
             spans = get_spans(uroman_lines_to_timestamp, segments, max_silence_padding_frames)
 
             sections = []

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ import ffmpeg
 from halo import Halo
 
 from lid import identify_language
-from mms.align_utils import get_alignments, get_spans, get_uroman_tokens, trim_silence_edges
+from mms.align_utils import get_alignments, get_spans, get_uroman_tokens
 from mms.text_normalization import text_normalize
 from timestamp_types import File, FileTimestamps, Match, Section
 
@@ -233,7 +233,6 @@ def align_matches(
                     continue
 
                 span = spans[i]
-                # span = trim_silence_edges(span, 25)
                 seg_start_idx = span[0].start
                 seg_end_idx = span[-1].end
 

--- a/utils.py
+++ b/utils.py
@@ -14,7 +14,7 @@ from mms.align_utils import get_alignments, get_spans, get_uroman_tokens
 from mms.text_normalization import text_normalize
 from timestamp_types import File, FileTimestamps, Match, Section
 
-mms_languages = json.load(open("mms_languages.json"))
+mms_languages = json.load(open("data/mms_languages.json"))
 
 
 def match_files(


### PR DESCRIPTION
## What

- Redefine `output` option to be output directory instead of output JSON filename.
- The output directory will receive a JSON and a SRT file for each input file match.

NOTE: This PR builds on top of PR #2, so should be merged after.

## Show

Input dir:
```
.
├── GEN.1.mp3
└── GEN.1.txt
```

Output dir:
```
.
├── GEN.1.json
└── GEN.1.srt
```
